### PR TITLE
chore: fix linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,8 @@ linters:
       rules: []
     gocritic:
       enabled-tags: [diagnostic, experimental, opinionated, performance, style]
-      disabled-checks: [dupImport, ifElseChain, octalLiteral, whyNoLint]
+      disabled-checks:
+        [dupImport, ifElseChain, octalLiteral, whyNoLint, commentedOutCode]
     funlen:
       lines: 100
       statements: 50

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.24.3
 
 require (
 	github.com/bytedance/sonic v1.14.1
+	github.com/caarlos0/env/v11 v11.3.1
 	github.com/go-resty/resty/v2 v2.16.5
 	github.com/joho/godotenv v1.5.1
 	github.com/redis/rueidis v1.0.64
@@ -14,7 +15,6 @@ require (
 require (
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
-	github.com/caarlos0/env/v11 v11.3.1 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect

--- a/internal/kami/kami.go
+++ b/internal/kami/kami.go
@@ -14,7 +14,7 @@ import (
 // KamiInterface defines the methods implemented by the Kami service client
 // Use this interface in callers to allow easy mocking and testing
 //
-//nolint:revive
+
 type KamiInterface interface {
 	ServeAxon(ServeAxonParams) (ExtrinsicHashResponse, error)
 	GetMetagraph(netuid int) (SubnetMetagraphResponse, error)

--- a/internal/kami/utils.go
+++ b/internal/kami/utils.go
@@ -11,7 +11,6 @@ func FindAxonByHotkey(metagraph SubnetMetagraph, hotkey string) *AxonInfo {
 }
 
 func GetHotkey(k *Kami) (string, error) {
-
 	keyringPair, err := k.GetKeyringPair()
 	if err != nil {
 		return "", err

--- a/internal/scoring/scoring.go
+++ b/internal/scoring/scoring.go
@@ -1,7 +1,7 @@
 // Package scoring contains logic to execute and calculate scoring
 package scoring
 
-func CalcPvPScores(discriminators map[string]string, generators map[string]string) (scores map[string]float64) {
+func CalcPvPScores(discriminators, generators map[string]string) (scores map[string]float64) {
 	/*
 		@param discriminators: map of discriminator addresses to their votes. A 'vote' is represented by the unique ID of selected code output.
 		@param generators: map of generator addresses to their generated output ID.
@@ -28,7 +28,7 @@ func CalcPvPScores(discriminators map[string]string, generators map[string]strin
 	return scores
 }
 
-func CalcTrapScores(discriminators map[string]string, positiveGenerators map[string]string, negativeGenerators map[string]string) (scores map[string]float64) {
+func CalcTrapScores(discriminators, positiveGenerators, negativeGenerators map[string]string) (scores map[string]float64) {
 	/*
 		@param discriminators: map of discriminator addresses to their votes. A 'vote' is represented by the unique ID of selected code output.
 		@param positiveGenerators: map of generator addresses to the superior output ID.
@@ -57,7 +57,7 @@ func CalcTrapScores(discriminators map[string]string, positiveGenerators map[str
 	return scores
 }
 
-func CalcPvVScores(discriminators map[string]string, generators map[string]string, validators map[string]string) (scores map[string]float64) {
+func CalcPvVScores(discriminators, generators, validators map[string]string) (scores map[string]float64) {
 	/*
 		@param discriminators: map of discriminator addresses to their votes. A 'vote' is represented by the unique ID of selected code output.
 		@param generators: map of generator addresses to their generated output ID.

--- a/internal/syntheticapi/synthetic.go
+++ b/internal/syntheticapi/synthetic.go
@@ -34,10 +34,7 @@ func decodePossiblyStringified[T any](raw json.RawMessage, out *T) error {
 	return nil
 }
 
-// SyntheticApiInterface describes the synthetic API client methods used.
-//
-//nolint:revive,staticcheck
-
+// SyntheticAPIInterface describes the synthetic API client methods used.
 type SyntheticAPIInterface interface {
 	GetQuestion() (GenerateQuestionResponse, error)
 	GetCodegenAnswer(qaID string) (GenerateAnswerResponse[CodegenAnswer], error)
@@ -45,13 +42,13 @@ type SyntheticAPIInterface interface {
 	OrderAnswer(question string) (OrderAnswerResponse, error)
 }
 
-// SyntheticApi wraps a REST client for the synthetic service.
+// SyntheticAPI wraps a REST client for the synthetic service.
 type SyntheticAPI struct {
 	cfg    *config.SyntheticAPIEnvConfig
 	client *resty.Client
 }
 
-// NewSyntheticApi creates a new synthetic API client bound to the configured URL.
+// NewSyntheticAPI creates a new synthetic API client bound to the configured URL.
 func NewSyntheticAPI(cfg *config.SyntheticAPIEnvConfig) (*SyntheticAPI, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("configuration cannot be nil")
@@ -134,8 +131,6 @@ func (s *SyntheticAPI) fetchCodegenFromField(qaID, field string) (CodegenAnswer,
 }
 
 // GetCodegenAnswer fetches a codegen answer by question ID.
-//
-//nolint:dupl
 func (s *SyntheticAPI) GetCodegenAnswer(qaID string) (GenerateAnswerResponse[CodegenAnswer], error) {
 	if qaID == "" {
 		return GenerateAnswerResponse[CodegenAnswer]{}, fmt.Errorf("qaID cannot be empty")

--- a/internal/syntheticapi/synthetic_test.go
+++ b/internal/syntheticapi/synthetic_test.go
@@ -35,7 +35,6 @@ func TestGetQuestion_Success(t *testing.T) {
 
 	cfg := &config.SyntheticAPIEnvConfig{SyntheticAPIUrl: ts.URL}
 	sa, err := NewSyntheticAPI(cfg)
-
 	if err != nil {
 		t.Fatalf("unexpected new error: %v", err)
 	}
@@ -60,7 +59,6 @@ func TestGetQuestion_Non2xx(t *testing.T) {
 
 	cfg := &config.SyntheticAPIEnvConfig{SyntheticAPIUrl: ts.URL}
 	sa, err := NewSyntheticAPI(cfg)
-
 	if err != nil {
 		panic(err)
 	}
@@ -96,7 +94,6 @@ func TestGetCodegenAnswer_Success(t *testing.T) {
 
 	cfg := &config.SyntheticAPIEnvConfig{SyntheticAPIUrl: ts.URL}
 	sa, err := NewSyntheticAPI(cfg)
-
 	if err != nil {
 		panic(err)
 	}
@@ -144,7 +141,6 @@ func TestGetQuestionAugment_Success(t *testing.T) {
 
 	cfg := &config.SyntheticAPIEnvConfig{SyntheticAPIUrl: ts.URL}
 	sa, err := NewSyntheticAPI(cfg)
-
 	if err != nil {
 		panic(err)
 	}
@@ -183,7 +179,6 @@ func TestOrderAnswer_Success(t *testing.T) {
 
 	cfg := &config.SyntheticAPIEnvConfig{SyntheticAPIUrl: ts.URL}
 	sa, err := NewSyntheticAPI(cfg)
-
 	if err != nil {
 		panic(err)
 	}

--- a/internal/syntheticapi/types.go
+++ b/internal/syntheticapi/types.go
@@ -34,6 +34,7 @@ type OrderAnswerResponse struct {
 }
 
 // ----------------------------- Codegen Types -----------------------------
+
 // CodegenAnswer is the top-level answer payload for codegen tasks.
 type CodegenAnswer struct {
 	Prompt    string            `json:"prompt"`
@@ -57,5 +58,3 @@ type CodegenFiles struct {
 	Filename string `json:"filename"`
 	Content  string `json:"content"`
 }
-
-// ----------------------------- Codegen Types -----------------------------

--- a/internal/taskapi/api.go
+++ b/internal/taskapi/api.go
@@ -11,16 +11,16 @@ import (
 	"github.com/tensorplex-labs/dojo/internal/config"
 )
 
-// TaskApiInterface is the interface for the task client methods used by validator.
+// TaskAPIInterface is the interface for the task client methods used by validator.
 type TaskAPIInterface interface {
 	CreateCodegenTask(
 		headers AuthHeaders,
 		req CreateTasksRequest[CodegenTaskMetadata],
 	) (Response[CreateTaskResponse], error)
-	SubmitCompletion(headers AuthHeaders, taskID string, completion string) (Response[SubmitCompletionResponse], error)
+	SubmitCompletion(headers AuthHeaders, taskID, completion string) (Response[SubmitCompletionResponse], error)
 }
 
-// TaskApi is a REST client wrapper for the task service.
+// TaskAPI is a REST client wrapper for the task service.
 type TaskAPI struct {
 	cfg    *config.TaskAPIEnvConfig
 	client *resty.Client
@@ -28,7 +28,6 @@ type TaskAPI struct {
 
 // NewTaskAPI constructs a new TaskAPI client.
 func NewTaskAPI(cfg *config.TaskAPIEnvConfig) (*TaskAPI, error) {
-
 	if cfg == nil {
 		return nil, fmt.Errorf("task api env configuration cannot be nil")
 	}
@@ -39,7 +38,6 @@ func NewTaskAPI(cfg *config.TaskAPIEnvConfig) (*TaskAPI, error) {
 		SetJSONUnmarshaler(sonic.Unmarshal)
 
 	return &TaskAPI{
-
 		cfg:    cfg,
 		client: client,
 	}, nil
@@ -51,7 +49,6 @@ func (t *TaskAPI) CreateCodegenTask(headers AuthHeaders, req CreateTasksRequest[
 	metadataBytes, err := sonic.Marshal(req.Metadata)
 	if err != nil {
 		return Response[CreateTaskResponse]{}, fmt.Errorf("marshal metadata: %w", err)
-
 	}
 
 	vals := url.Values{}
@@ -80,7 +77,7 @@ func (t *TaskAPI) CreateCodegenTask(headers AuthHeaders, req CreateTasksRequest[
 	return out, nil
 }
 
-func (t *TaskAPI) SubmitCompletion(headers AuthHeaders, taskID string, completion string) (Response[SubmitCompletionResponse], error) {
+func (t *TaskAPI) SubmitCompletion(headers AuthHeaders, taskID, completion string) (Response[SubmitCompletionResponse], error) {
 	var out Response[SubmitCompletionResponse]
 
 	metadataBytes, err := sonic.Marshal(completion)

--- a/internal/taskapi/types.go
+++ b/internal/taskapi/types.go
@@ -40,6 +40,8 @@ type ErrorResponse = Response[struct{}]
 type PaginatedResponse[T any] = Response[T]
 
 // ------------- Task Types -------------//
+
+// CodegenTaskMetadata represents the metadata for a codegen task
 type CodegenTaskMetadata struct {
 	Prompt              string `json:"prompt"`
 	ValidatorCompletion string `json:"validator_completion"`

--- a/internal/utils/chain_utils/check_stake.go
+++ b/internal/utils/chain_utils/check_stake.go
@@ -1,10 +1,11 @@
+// Package chainutils/check_stake.go contains stake checking logic
 package chainutils
 
 import (
 	"os"
 )
 
-func CheckIfMiner(alphaStake float64, rootStake float64) (bool, error) {
+func CheckIfMiner(alphaStake, rootStake float64) (bool, error) {
 	effectiveRootStake := rootStake * 0.18
 
 	effectiveStake := alphaStake + effectiveRootStake

--- a/internal/utils/chain_utils/ip.go
+++ b/internal/utils/chain_utils/ip.go
@@ -1,3 +1,4 @@
+// Package chainutils/ip.go provides utility functions for working with IP addresses
 package chainutils
 
 import (
@@ -17,7 +18,6 @@ func GetExternalIP() (net.IP, error) {
 	client := http.Client{Timeout: 5 * time.Second}
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.ipify.org", http.NoBody)
-
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}

--- a/internal/utils/logger/logger.go
+++ b/internal/utils/logger/logger.go
@@ -1,15 +1,15 @@
+// Package logger provides a global logger for the application
 package logger
 
 import (
 	"flag"
 	"os"
 
-	"go.uber.org/zap"
-
 	"github.com/joho/godotenv"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/rs/zerolog/pkgerrors"
+	"go.uber.org/zap"
 )
 
 var Logger *zap.Logger

--- a/internal/utils/redis/redis.go
+++ b/internal/utils/redis/redis.go
@@ -1,3 +1,4 @@
+// Package redis provides a Redis client for interacting with Redis
 package redis
 
 import (
@@ -6,6 +7,7 @@ import (
 	"time"
 
 	"github.com/redis/rueidis"
+
 	"github.com/tensorplex-labs/dojo/internal/config"
 )
 
@@ -17,7 +19,7 @@ type Redis struct {
 type RedisInterface interface {
 	Get(ctx context.Context, key string) (string, error)
 	GetMulti(ctx context.Context, keys []string) (map[string]string, error)
-	Set(ctx context.Context, key string, value string, ttl time.Duration) error
+	Set(ctx context.Context, key, value string, ttl time.Duration) error
 	SetMulti(ctx context.Context, kv map[string]string) error
 	LRange(ctx context.Context, key string, start, stop int64) ([]string, error)
 	LLen(ctx context.Context, key string) (int64, error)
@@ -76,7 +78,7 @@ func (r *Redis) GetMulti(ctx context.Context, keys []string) (map[string]string,
 	return m, nil
 }
 
-func (r *Redis) Set(ctx context.Context, key string, value string, ttl time.Duration) error {
+func (r *Redis) Set(ctx context.Context, key, value string, ttl time.Duration) error {
 	if ttl > 0 {
 		return r.client.Do(ctx, r.client.B().Set().Key(key).Value(value).Ex(ttl).Build()).Error()
 	}

--- a/internal/validator/tasks.go
+++ b/internal/validator/tasks.go
@@ -124,7 +124,7 @@ func (v *Validator) canStartTaskRound(ctx context.Context) bool {
 }
 
 // calling via redis so it doesn't pop the tasks out of the list
-func (v *Validator) taskTrackerPure(ctx context.Context) (int, int, error) {
+func (v *Validator) taskTrackerPure(ctx context.Context) (total, completed int, err error) {
 	vals, err := v.Redis.LRange(ctx, "synthetic:questions", 0, -1)
 	if err != nil {
 		return 0, 0, fmt.Errorf("lrange: %w", err)

--- a/internal/validator/types.go
+++ b/internal/validator/types.go
@@ -34,7 +34,7 @@ type Codegen struct {
 	Completion any `json:"completion"`
 }
 
-// redis cached values for tasks
+// CachedTasks represents redis cached values for tasks
 type CachedTasks struct {
 	Question string `json:"question"`
 	QaID     string `json:"qa_id"`

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -100,7 +100,6 @@ func (v *Validator) runTicker(ctx context.Context, d time.Duration, fn func()) {
 
 // Start initializes validator hotkey and kicks off periodic routines.
 func (v *Validator) Start() {
-
 	v.Wg.Add(3)
 	go v.runTicker(v.Ctx, v.IntervalConfig.TaskRoundInterval, func() {
 		v.sendTaskRound()


### PR DESCRIPTION
changelog:
- ran golangci-lint --fix to auto fix linting errors
- disabled commentedOutCode rule from linting
- fixed low hanging-linting errors, reducing number of errors to 6
- 6 remaining errors are code logic. so will leave it to the author to fix. 