### PR TITLE
fix: trap tasks are scored correctly instead of being removed after first scoring

### DIFF
--- a/internal/validator/codegen_task.go
+++ b/internal/validator/codegen_task.go
@@ -87,7 +87,7 @@ func (v *Validator) processCodegenTask(activeMinerUIDs []int64, processedMiners 
 		}
 
 		if trapValue != "" {
-			if err = v.Redis.Set(v.Ctx, fmt.Sprintf("trap:%s", taskCreationResponse.Data.TaskID), trapValue, 0); err != nil {
+			if err = v.Redis.Set(v.Ctx, fmt.Sprintf("trap:%s", taskCreationResponse.Data.TaskID), trapValue, 48*time.Hour); err != nil {
 				log.Error().Err(err).Msgf("failed to set trap for task ID %s", taskCreationResponse.Data.TaskID)
 			} else {
 				log.Debug().Msgf("Set trap for task ID %s", taskCreationResponse.Data.TaskID)

--- a/internal/validator/codegen_task.go
+++ b/internal/validator/codegen_task.go
@@ -87,7 +87,7 @@ func (v *Validator) processCodegenTask(activeMinerUIDs []int64, processedMiners 
 		}
 
 		if trapValue != "" {
-			if err = v.Redis.Set(v.Ctx, fmt.Sprintf("trap:%s", taskCreationResponse.Data.TaskID), trapValue, 48*time.Hour); err != nil {
+			if err = v.Redis.Set(v.Ctx, fmt.Sprintf("trap:%s", taskCreationResponse.Data.TaskID), trapValue, 2*v.IntervalConfig.ScoreResetInterval); err != nil {
 				log.Error().Err(err).Msgf("failed to set trap for task ID %s", taskCreationResponse.Data.TaskID)
 			} else {
 				log.Debug().Msgf("Set trap for task ID %s", taskCreationResponse.Data.TaskID)

--- a/internal/validator/score_task.go
+++ b/internal/validator/score_task.go
@@ -156,10 +156,6 @@ func (v *Validator) checkIfTrapTask(taskID string) (trapBool bool, hotkey string
 
 	if negativeGeneratorHotkey != "" {
 		log.Debug().Msgf("Task %s is a trap task (negative generator: %s)", taskID, negativeGeneratorHotkey)
-		if delErr := v.Redis.Del(v.Ctx, trapRedisKey); delErr != nil {
-			// TODO: how to handle this redis delete key error better
-			log.Error().Err(delErr).Msgf("Failed to delete trap key %s", trapRedisKey)
-		}
 		return true, negativeGeneratorHotkey
 	}
 


### PR DESCRIPTION
the bug is: trap key will be deleted after the first scoring, and will never be scored as trap task in subsequent scoring in the rolling-window method

fix: set a TTL to the key that 2X of the rolling window period